### PR TITLE
Support Debian

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,7 +21,7 @@ class nsswitch::params {
                 $shadow_default     = ['files']
                 $sudoers_default    = undef
     }
-    'Ubuntu': {
+    /Ubuntu|Debian/: {
                 $nsswitch_path = '/etc/nsswitch.conf'
 
                 $aliases_default    = undef


### PR DESCRIPTION
Debian since 5.0 (Lenny) has the exact same default nsswitch.conf as this module has for Ubuntu.
