### PR TITLE
Proposed *_compat updates to nsswitch.conf.erb and params.pp

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,22 +24,24 @@ class nsswitch::params {
 
   case $::operatingsystem {
     /CentOS|RedHat|Amazon|OracleLinux|Scientific/: {
-                $aliases_default    = ['files','nisplus']
-                $automount_default  = ['files','nisplus']
-                $bootparams_default = ['nisplus [NOTFOUND=return]','files']
-                $ethers_default     = ['files']
-                $group_default      = ['files']
-                $hosts_default      = ['files','dns']
-                $netgroup_default   = ['nisplus']
-                $netmasks_default   = ['files']
-                $networks_default   = ['files']
-                $passwd_default     = ['files']
-                $protocols_default  = ['files']
-                $publickey_default  = ['nisplus']
-                $rpc_default        = ['files']
-                $services_default   = ['files']
-                $shadow_default     = ['files']
-                $sudoers_default    = undef
+                $aliases_default       = ['files','nisplus']
+                $automount_default     = ['files','nisplus']
+                $bootparams_default    = ['nisplus [NOTFOUND=return]','files']
+                $ethers_default        = ['files']
+                $group_default         = ['files']
+                $hosts_default         = ['files','dns']
+                $netgroup_default      = ['nisplus']
+                $netmasks_default      = ['files']
+                $networks_default      = ['files']
+                $passwd_default        = ['files']
+                $passwd_compat_default = undef
+                $protocols_default     = ['files']
+                $publickey_default     = ['nisplus']
+                $rpc_default           = ['files']
+                $services_default      = ['files']
+                $shadow_default        = ['files']
+                $shadow_compat_default = undef
+                $sudoers_default       = undef
     }
     'Fedora': {
                 $aliases_default    = ['files','nisplus']

--- a/templates/nsswitch.conf.erb
+++ b/templates/nsswitch.conf.erb
@@ -1,7 +1,12 @@
 # This file is controlled by Puppet
-
+<% if @passwd_compat -%>
+passwd_compat:     <%= [*@passwd_compat].join(" ") %>
+<% end -%>
 <% if @passwd -%>
 passwd:     <%= [*@passwd].join(" ") %>
+<% end -%>
+<% if @shadow_compat -%>
+shadow_compat:     <%= [*@shadow_compat].join(" ") %>
 <% end -%>
 <% if @shadow -%>
 shadow:     <%= [*@shadow].join(" ") %>
@@ -48,4 +53,3 @@ automount:  <%= [*@automount].join(" ") %>
 <% if @aliases -%>
 aliases:    <%= [*@aliases].join(" ") %>
 <% end -%>
-


### PR DESCRIPTION
When using netgroups to restrict logins, the shadow_compat and passwd_compat  NSS service definitions are used.