### PR TITLE
Added support for CloudLinux

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -63,7 +63,7 @@ class nsswitch::params {
                 $shadow_default     = ['files']
                 $sudoers_default    = undef
     }
-    /Ubuntu|Debian/: {
+    /Ubuntu|Debian|CloudLinux/: {
                 $aliases_default    = undef
                 $automount_default  = undef
                 $bootparams_default = undef

--- a/metadata.json
+++ b/metadata.json
@@ -35,6 +35,9 @@
     "operatingsystem": "Scientific"
   },
   {
+    "operatingsystem": "CloudLinux"
+  },
+  {
     "operatingsystem": "Ubuntu",
     "operatingsystemrelease": [
       "12.04",

--- a/spec/classes/nsswitch_spec.rb
+++ b/spec/classes/nsswitch_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'nsswitch', :type => :class do
-  %w{CentOS RedHat Amazon OracleLinux Scientific Fedora SLES Solaris Debian Ubuntu Gentoo}.each do |os|
+  %w{CentOS RedHat Amazon OracleLinux Scientific Fedora SLES Solaris Debian Ubuntu Gentoo CloudLinux}.each do |os|
     context "when used with default parameter on #{os}" do
       let(:facts) { {:operatingsystem => os } }
       it { is_expected.to compile.with_all_deps }


### PR DESCRIPTION
nsswitch.conf looks (by default) the most on the ones that are supplied by Debian/Ubuntu, therefor I placed it there (Though CL is actually a CentOS based distro).