### PR TITLE
moves to Puppet 4 syntax

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,8 +1,5 @@
 fixtures:
   repositories:
-    validate_multi:
-      repo: "git://github.com/trlinkin/puppet-validate_multi"
-      ref: "0.1.0"
     stdlib:
       repo: "git://github.com/puppetlabs/puppetlabs-stdlib"
       ref: "4.3.2"

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 gem 'rspec-core', '3.3.0',     :require => false
 gem 'rspec-puppet', '2.2.0',   :require => false
-gem 'rake',                    :require => false
+gem 'rake', '< 11.0',          :require => false
 gem 'puppetlabs_spec_helper',  :require => false
 gem 'puppet-lint',             :require => false
 gem 'metadata-json-lint',      :require => false

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -116,94 +116,24 @@
 # Copyright 2013 Thomas Linkin, Marcellus Siegburg
 #
 class nsswitch (
-  $aliases    = $nsswitch::params::aliases_default,
-  $automount  = $nsswitch::params::automount_default,
-  $bootparams = $nsswitch::params::bootparams_default,
-  $ethers     = $nsswitch::params::ethers_default,
-  $group      = $nsswitch::params::group_default,
-  $gshadow    = $nsswitch::params::gshadow_default,
-  $hosts      = $nsswitch::params::hosts_default,
-  $netgroup   = $nsswitch::params::netgroup_default,
-  $netmasks   = $nsswitch::params::netmasks_default,
-  $networks   = $nsswitch::params::networks_default,
-  $passwd     = $nsswitch::params::passwd_default,
-  $protocols  = $nsswitch::params::protocols_default,
-  $publickey  = $nsswitch::params::publickey_default,
-  $rpc        = $nsswitch::params::rpc_default,
-  $services   = $nsswitch::params::services_default,
-  $shadow     = $nsswitch::params::shadow_default,
-  $sudoers    = $nsswitch::params::sudoers_default,
+  Array[String] $aliases    = $nsswitch::params::aliases_default,
+  Array[String] $automount  = $nsswitch::params::automount_default,
+  Array[String] $bootparams = $nsswitch::params::bootparams_default,
+  Array[String] $ethers     = $nsswitch::params::ethers_default,
+  Array[String] $group      = $nsswitch::params::group_default,
+  Array[String] $gshadow    = $nsswitch::params::gshadow_default,
+  Array[String] $hosts      = $nsswitch::params::hosts_default,
+  Array[String] $netgroup   = $nsswitch::params::netgroup_default,
+  Array[String] $netmasks   = $nsswitch::params::netmasks_default,
+  Array[String] $networks   = $nsswitch::params::networks_default,
+  Array[String] $passwd     = $nsswitch::params::passwd_default,
+  Array[String] $protocols  = $nsswitch::params::protocols_default,
+  Array[String] $publickey  = $nsswitch::params::publickey_default,
+  Array[String] $rpc        = $nsswitch::params::rpc_default,
+  Array[String] $services   = $nsswitch::params::services_default,
+  Array[String] $shadow     = $nsswitch::params::shadow_default,
+  Array[String] $sudoers    = $nsswitch::params::sudoers_default,
 ) inherits nsswitch::params {
-
-  # Determine the value for Aliases
-  if $aliases {
-    validate_multi($aliases,'string','array')
-  }
-  # Determine the value for Auto Mounting
-  if $automount {
-    validate_multi($automount,'string','array')
-  }
-  # Determine the value for Boot Params
-  if $bootparams {
-    validate_multi($bootparams,'string','array')
-  }
-  # Determine the value for Ethers
-  if $ethers {
-    validate_multi($ethers,'string','array')
-  }
-  # Determine the value for Groups
-  if $group {
-    validate_multi($group,'string','array')
-  }
-  # Determine the value for Shadow
-  if $gshadow {
-    validate_multi($gshadow,'string','array')
-  }
-  # Determine the value for Hosts
-  if $hosts {
-    validate_multi($hosts,'string','array')
-  }
-  # Determine the value for Netgroup
-  if $netgroup {
-    validate_multi($netgroup,'string','array')
-  }
-  # Determine the value for Netmasks
-  if $netmasks {
-    validate_multi($netmasks,'string','array')
-  }
-  # Determine the value for Networks
-  if $networks {
-    validate_multi($networks,'string','array')
-  }
-  # Determine the value for PASSWD
-  if $passwd  {
-    validate_multi($passwd,'string','array')
-  }
-  # Determine the value for Protocols
-  if $protocols {
-    validate_multi($protocols,'string','array')
-  }
-  # Determine the value for Public Key
-  if $publickey {
-    validate_multi($publickey,'string','array')
-  }
-  # Determine the value for RPC
-  if $rpc {
-    validate_multi($rpc,'string','array')
-  }
-  # Determine the value for Services
-  if $services {
-    validate_multi($services,'string','array')
-  }
-  # Determine the value for Shadow
-  if $shadow {
-    validate_multi($shadow,'string','array')
-  }
-  # Determine the value for Sudoers
-  if $sudoers {
-    validate_multi($sudoers,'string','array')
-  }
-
   file { 'nsswitch.conf':
     ensure  => file,
     path    => '/etc/nsswitch.conf',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -45,14 +45,14 @@ class nsswitch::params {
       $aliases_default    = ['files','nisplus']
       $bootparams_default = ['nisplus [NOTFOUND=return]','files']
       $ethers_default     = ['files']
-      $gshadow_default    = undef
+      $gshadow_default    = []
       $hosts_default      = ['files','dns']
       $netmasks_default   = ['files']
       $networks_default   = ['files']
       $protocols_default  = ['files']
       $publickey_default  = ['nisplus']
       $rpc_default        = ['files']
-      $sudoers_default    = undef
+      $sudoers_default    = []
     }
     'Fedora': {
       $aliases_default    = ['files','nisplus']
@@ -60,7 +60,7 @@ class nsswitch::params {
       $bootparams_default = ['nisplus [NOTFOUND=return]','files']
       $ethers_default     = ['files']
       $group_default      = ['files']
-      $gshadow_default    = undef
+      $gshadow_default    = []
       $hosts_default      = ['files',
       'mdns4_minimal [NOTFOUND=return]',
       'dns']
@@ -73,26 +73,26 @@ class nsswitch::params {
       $rpc_default        = ['files']
       $services_default   = ['files']
       $shadow_default     = ['files']
-      $sudoers_default    = undef
+      $sudoers_default    = []
     }
     /Ubuntu|Debian/: {
-      $aliases_default    = undef
-      $automount_default  = undef
-      $bootparams_default = undef
+      $aliases_default    = []
+      $automount_default  = []
+      $bootparams_default = []
       $ethers_default     = ['db','files']
       $group_default      = ['compat']
       $gshadow_default    = ['files']
       $hosts_default      = ['files','dns']
       $netgroup_default   = ['nis']
-      $netmasks_default   = undef
+      $netmasks_default   = []
       $networks_default   = ['files']
       $passwd_default     = ['compat']
       $protocols_default  = ['db','files']
-      $publickey_default  = undef
+      $publickey_default  = []
       $rpc_default        = ['db','files']
       $services_default   = ['db','files']
       $shadow_default     = ['compat']
-      $sudoers_default    = undef
+      $sudoers_default    = []
     }
     'SLES': {
       $aliases_default    = ['files']
@@ -100,7 +100,7 @@ class nsswitch::params {
       $bootparams_default = ['files']
       $ethers_default     = ['files']
       $group_default      = ['compat']
-      $gshadow_default    = undef
+      $gshadow_default    = []
       $hosts_default      = ['files','dns']
       $netgroup_default   = ['files']
       $netmasks_default   = ['files']
@@ -110,13 +110,13 @@ class nsswitch::params {
       $publickey_default  = ['files']
       $rpc_default        = ['files']
       $services_default   = ['files']
-      $shadow_default     = undef
-      $sudoers_default    = undef
+      $shadow_default     = []
+      $sudoers_default    = []
     }
     'Solaris': {
       $passwd_default       = ['files','nisplus']
       $group_default        = ['files','nisplus']
-      $gshadow_default    = undef
+      $gshadow_default      = []
       $hosts_default        = ['files','dns','nisplus']
       $services_default     = ['nisplus','files']
       $networks_default     = ['nisplus','files']
@@ -129,6 +129,8 @@ class nsswitch::params {
       $netgroup_default     = ['nisplus']
       $automount_default    = ['files','nisplus']
       $aliases_default      = ['files','nisplus']
+      $shadow_default       = []
+      $sudoers_default      = []
     }
     'Gentoo': {
       $aliases_default    = ['files']
@@ -136,18 +138,18 @@ class nsswitch::params {
       $bootparams_default = ['files']
       $ethers_default     = ['db','files']
       $group_default      = ['compat']
-      $gshadow_default    = undef
+      $gshadow_default    = []
       $hosts_default      = ['files','dns']
       $netgroup_default   = ['files']
       $netmasks_default   = ['files']
       $networks_default   = ['files','dns']
       $passwd_default     = ['compat']
       $protocols_default  = ['db','files']
-      $publickey_default  = undef
+      $publickey_default  = []
       $rpc_default        = ['db','files']
       $services_default   = ['db','files']
       $shadow_default     = ['compat']
-      $sudoers_default    = undef
+      $sudoers_default    = []
     }
     default: {
       fail("${::operatingsystem} is not a supported operating system.")

--- a/metadata.json
+++ b/metadata.json
@@ -58,10 +58,6 @@
   ],
   "requirements": [
     {
-      "name": "pe",
-      "version_requirement": ">= 3.0.0 < 2015.2.0"
-    },
-    {
       "name": "facter",
       "version_requirement": ">= 1.7.0"
     },
@@ -74,10 +70,6 @@
     {
     "name": "puppetlabs/stdlib",
     "version_requirement": ">= 1.0.0"
-  },
-  {
-    "name": "trlinkin/validate_multi",
-    "version_requirement": ">= 0.1.0"
-  }
+    }
   ]
 }


### PR DESCRIPTION
This ditches `validate_multi` for the appropriate Puppet 4 type.
Furthermore, it makes the unit tests for Solaris work.