### PR TITLE
FreeBSD Support (Puppet 3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,12 @@ language: ruby
 script:
   - "bundle exec rake syntax"
   - "bundle exec rake lint"
-  - "bundle exec rake metadata"
+  - "bundle exec rake metadata_lint"
   - "bundle exec rake spec SPEC_OPTS='--color --format documentation'"
 rvm:
  - 1.9.3-p484
  - 2.0.0
+ - 2.1.9
  - ruby-head
 env:
  - PUPPET_GEM_VERSION="< 4.0.0"
@@ -15,6 +16,10 @@ matrix:
   exclude:
     - rvm: ruby-head
       env: PUPPET_GEM_VERSION="< 4.0.0"
+    - rvm: 1.9.3-p484
+      env: PUPPET_GEM_VERSION="> 4.0.0"
+    - rvm: 2.0.0
+      env: PUPPET_GEM_VERSION="> 4.0.0"
   allow_failures:
     - rvm: ruby-head
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ script:
   - "bundle exec rake metadata_lint"
   - "bundle exec rake spec SPEC_OPTS='--color --format documentation'"
 rvm:
- - 1.9.3-p484
  - 2.0.0
  - 2.1.9
  - ruby-head
@@ -16,8 +15,6 @@ matrix:
   exclude:
     - rvm: ruby-head
       env: PUPPET_GEM_VERSION="< 4.0.0"
-    - rvm: 1.9.3-p484
-      env: PUPPET_GEM_VERSION="> 4.0.0"
     - rvm: 2.0.0
       env: PUPPET_GEM_VERSION="> 4.0.0"
   allow_failures:

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 gem 'rspec-core', '3.3.0',     :require => false
 gem 'rspec-puppet', '2.2.0',   :require => false
-gem 'rake',                    :require => false
+gem 'rake', '< 11.0',          :require => false
 gem 'puppetlabs_spec_helper',  :require => false
 gem 'puppet-lint',             :require => false
 gem 'metadata-json-lint',      :require => false

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This module should be capable of supporting the following systems:
  * Fedora
  * Oracle Linux 5.x, 6.x
  * Gentoo
+ * FreeBSD
 
 Testing has only confirmed functionality on the following:
   * Ubuntu 12.4
@@ -33,8 +34,8 @@ Testing has only confirmed functionality on the following:
 #### nsswitch class
 
 This is the class by which you will manage the nsswitch.conf file. There
-is one paramter per standard database NSS supports. The class accepts both strings 
-and arrays as paramters. The benefit being, you could possibly merge an array
+is one parameter per standard database NSS supports. The class accepts both strings
+and arrays as parameters. The benefit being, you could possibly merge an array
 of options with hiera. When using an array, each element should be the
 lookup service followed by the reaction statement.
 
@@ -55,6 +56,7 @@ Available parameters are:
 * publickey
 * rpc
 * services
+* shells
 * sudo
 
 
@@ -100,6 +102,8 @@ class { 'nsswitch':
 
 ### Changelog
 
+* Add FreeBSD support
+* Add the ability to set the **shells** value
 * Change quoting of string in `params.pp`
 * Correct `.travis.yml` tests
 * Add unit tests for different EL versions
@@ -149,4 +153,3 @@ class { 'nsswitch':
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,6 +28,21 @@
 #   Ethernet numbers.
 #   *Optional* (defaults to $nsswitch::params::ethers_default)
 #
+# [*file_group*]
+#
+#   Group of the nsswitch.conf file
+#   *Optional* (defaults to $nsswitch::params::file_group)
+#
+# [*file_owner*]
+#
+#   Owner of the nsswitch.conf file
+#   *Optional* (defaults to $nsswitch::params::file_owner)
+#
+# [*file_perms*]
+#
+#   Permissions for the nsswitch.conf file
+#   *Optional* (defaults to $nsswitch::params::file_perms)
+#
 # [*group*]
 #
 #   Groups of users, used by getgrent() and related functions.
@@ -85,6 +100,11 @@
 #   Network services, used by getservent() and related functions.
 #   *Optional* (defaults to $nsswitch::params::services_default)
 #
+# [*shells*]
+#
+#   Valid user shells, used by getusershell() and related functions.
+#   *Optional* (defaults to $nsswitch::params::shells_default)
+#
 # [*shadow*]
 #
 #   Shadow user passwords, used by getspnam() and related functions.
@@ -120,6 +140,9 @@ class nsswitch (
   $automount  = $nsswitch::params::automount_default,
   $bootparams = $nsswitch::params::bootparams_default,
   $ethers     = $nsswitch::params::ethers_default,
+  $file_group = $nsswitch::params::file_group,
+  $file_owner = $nsswitch::params::file_owner,
+  $file_perms = $nsswitch::params::file_perms,
   $group      = $nsswitch::params::group_default,
   $gshadow    = $nsswitch::params::gshadow_default,
   $hosts      = $nsswitch::params::hosts_default,
@@ -132,6 +155,7 @@ class nsswitch (
   $rpc        = $nsswitch::params::rpc_default,
   $services   = $nsswitch::params::services_default,
   $shadow     = $nsswitch::params::shadow_default,
+  $shells     = $nsswitch::params::shells_default,
   $sudoers    = $nsswitch::params::sudoers_default,
 ) inherits nsswitch::params {
 
@@ -199,6 +223,10 @@ class nsswitch (
   if $shadow {
     validate_multi($shadow,'string','array')
   }
+  # Determine the value for Shadow
+  if $shells {
+    validate_multi($shells,'string','array')
+  }
   # Determine the value for Sudoers
   if $sudoers {
     validate_multi($sudoers,'string','array')
@@ -207,9 +235,9 @@ class nsswitch (
   file { 'nsswitch.conf':
     ensure  => file,
     path    => '/etc/nsswitch.conf',
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0644',
+    owner   => $file_owner,
+    group   => $file_group,
+    mode    => $file_perms,
     content => template('nsswitch/nsswitch.conf.erb'),
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,6 +22,9 @@
 #
 class nsswitch::params {
 
+  $file_owner = 'root'
+  $file_perms = '0644'
+
   case $::operatingsystem {
     /CentOS|RedHat|Amazon|OEL|OracleLinux|Scientific|CloudLinux/: {
       if $::operatingsystemmajrelease == '7' {
@@ -42,6 +45,8 @@ class nsswitch::params {
         $netgroup_default   = ['nisplus']
       }
 
+      $file_group         = 'root'
+
       $aliases_default    = ['files','nisplus']
       $bootparams_default = ['nisplus [NOTFOUND=return]','files']
       $ethers_default     = ['files']
@@ -52,9 +57,12 @@ class nsswitch::params {
       $protocols_default  = ['files']
       $publickey_default  = ['nisplus']
       $rpc_default        = ['files']
+      $shells_default     = undef
       $sudoers_default    = undef
     }
     'Fedora': {
+      $file_group         = 'root'
+
       $aliases_default    = ['files','nisplus']
       $automount_default  = ['files','nisplus']
       $bootparams_default = ['nisplus [NOTFOUND=return]','files']
@@ -73,9 +81,12 @@ class nsswitch::params {
       $rpc_default        = ['files']
       $services_default   = ['files']
       $shadow_default     = ['files']
+      $shells_default     = undef
       $sudoers_default    = undef
     }
     /Ubuntu|Debian/: {
+      $file_group         = 'root'
+
       $aliases_default    = undef
       $automount_default  = undef
       $bootparams_default = undef
@@ -92,9 +103,12 @@ class nsswitch::params {
       $rpc_default        = ['db','files']
       $services_default   = ['db','files']
       $shadow_default     = ['compat']
+      $shells_default     = undef
       $sudoers_default    = undef
     }
     'SLES': {
+      $file_group         = 'root'
+
       $aliases_default    = ['files']
       $automount_default  = ['files']
       $bootparams_default = ['files']
@@ -111,26 +125,34 @@ class nsswitch::params {
       $rpc_default        = ['files']
       $services_default   = ['files']
       $shadow_default     = undef
+      $shells_default     = undef
       $sudoers_default    = undef
     }
     'Solaris': {
-      $passwd_default       = ['files','nisplus']
-      $group_default        = ['files','nisplus']
+      $file_group         = 'root'
+
+      $aliases_default    = ['files','nisplus']
+      $automount_default  = ['files','nisplus']
+      $bootparams_default = ['nisplus','files']
+      $ethers_default     = ['nisplus','files']
+      $group_default      = ['files','nisplus']
       $gshadow_default    = undef
-      $hosts_default        = ['files','dns','nisplus']
-      $services_default     = ['nisplus','files']
-      $networks_default     = ['nisplus','files']
-      $protocols_default    = ['nisplus','files']
-      $rpc_default          = ['nisplus','files']
-      $ethers_default       = ['nisplus','files']
-      $netmasks_default     = ['files','nisplus']
-      $bootparams_default   = ['nisplus','files']
-      $publickey_default    = ['nisplus']
-      $netgroup_default     = ['nisplus']
-      $automount_default    = ['files','nisplus']
-      $aliases_default      = ['files','nisplus']
+      $hosts_default      = ['files','dns','nisplus']
+      $netgroup_default   = ['nisplus']
+      $netmasks_default   = ['files','nisplus']
+      $networks_default   = ['nisplus','files']
+      $passwd_default     = ['files','nisplus']
+      $protocols_default  = ['nisplus','files']
+      $publickey_default  = ['nisplus']
+      $rpc_default        = ['nisplus','files']
+      $services_default   = ['nisplus','files']
+      $shadow_default     = undef
+      $shells_default     = undef
+      $sudoers_default    = undef
     }
     'Gentoo': {
+      $file_group         = 'root'
+
       $aliases_default    = ['files']
       $automount_default  = ['files']
       $bootparams_default = ['files']
@@ -147,6 +169,29 @@ class nsswitch::params {
       $rpc_default        = ['db','files']
       $services_default   = ['db','files']
       $shadow_default     = ['compat']
+      $shells_default     = undef
+      $sudoers_default    = undef
+    }
+    'FreeBSD': {
+      $file_group         = 'wheel'
+
+      $aliases_default    = undef
+      $automount_default  = undef
+      $bootparams_default = undef
+      $ethers_default     = undef
+      $group_default      = ['compat']
+      $gshadow_default    = undef
+      $hosts_default      = ['files','dns']
+      $netgroup_default   = undef
+      $netmasks_default   = undef
+      $networks_default   = ['files']
+      $passwd_default     = ['compat']
+      $protocols_default  = ['files']
+      $publickey_default  = undef
+      $rpc_default        = ['files']
+      $services_default   = ['compat']
+      $shadow_default     = undef
+      $shells_default     = ['files']
       $sudoers_default    = undef
     }
     default: {

--- a/metadata.json
+++ b/metadata.json
@@ -58,10 +58,6 @@
   ],
   "requirements": [
     {
-      "name": "pe",
-      "version_requirement": ">= 3.0.0 < 2015.2.0"
-    },
-    {
       "name": "facter",
       "version_requirement": ">= 1.7.0"
     },
@@ -73,11 +69,11 @@
   "dependencies": [
     {
     "name": "puppetlabs/stdlib",
-    "version_requirement": ">= 1.0.0"
+    "version_requirement": ">= 1.0.0 <= 4.13.1"
   },
   {
     "name": "trlinkin/validate_multi",
-    "version_requirement": ">= 0.1.0"
+    "version_requirement": ">= 0.1.0 < 2.0.0"
   }
   ]
 }

--- a/spec/classes/nsswitch_spec.rb
+++ b/spec/classes/nsswitch_spec.rb
@@ -29,7 +29,7 @@ describe 'nsswitch', :type => :class do
     end
   end
 
-  context 'when used on an unsupported Operatin System' do
+  context 'when used on an unsupported Operating System' do
     let(:facts) { {:operatingsystem => 'Windows' } }
     it do
       is_expected.to raise_error(Puppet::Error, /is not a supported operating system\./)

--- a/templates/nsswitch.conf.erb
+++ b/templates/nsswitch.conf.erb
@@ -51,4 +51,7 @@ automount:  <%= [*@automount].join(" ") %>
 <% if @aliases -%>
 aliases:    <%= [*@aliases].join(" ") %>
 <% end -%>
+<% if @shells -%>
+shells:    <%= [*@shells].join(" ") %>
+<% end -%>
 


### PR DESCRIPTION
* Add "shells" support
* Add custom ownership, group, and permissions settings for nsswitch.conf as well as defaults for each OS in params.pp
* Fix ordering for Solaris defaults in params.pp and add missing defaults
* Update README file
* Update Gemfile to use rake < 11.0 to fix Travis failures
* Update .travis.yml metadata lint command
* Fix lint errors in metadata.json
* Correct ruby version mismatches with Puppet 4
* Fix typo in spec file