### PR TITLE
Update fixtures to 6.x stdlib

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,6 +2,6 @@ fixtures:
   repositories:
     stdlib:
       repo: "git://github.com/puppetlabs/puppetlabs-stdlib"
-      ref: "4.3.2"
+      ref: "v6.2.0"
   symlinks:
     nsswitch: "#{source_dir}"


### PR DESCRIPTION
This commit updates the `.fixtures.yml` to use the most recent version of
puppetlabs/stdlib in CI testing. This change will allow the module to be
verified against the 6.x generation of puppetlabs/stdlib.