### PR TITLE
The Future is Now - Deps and Support Bumps

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.25.0 < 7.0.0"
+      "version_requirement": ">= 4.25.0 < 9.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -19,7 +19,8 @@
       "operatingsystemrelease": [
         "6",
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
@@ -27,6 +28,20 @@
       "operatingsystemrelease": [
         "6",
         "7",
+        "8",
+        "9"
+      ]
+    },
+    {
+      "operatingsystem": "AlmaLinux",
+      "operatingsystemrelease": [
+        "8",
+        "9"
+      ]
+    },
+    {
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
         "8"
       ]
     },
@@ -35,14 +50,16 @@
       "operatingsystemrelease": [
         "6",
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "CloudLinux",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
@@ -74,6 +91,10 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
+        "20.04",
+        "18.04",
+        "16.04",
+        "14.04",
         "12.04",
         "10.04"
       ]
@@ -81,8 +102,11 @@
     {
       "operatingsystem": "Debian",
        "operatingsystemrelease": [
-        "12.04",
-        "10.04"
+         "13",
+         "12",
+         "11",
+         "10",
+         "9"
       ]
     },
     {
@@ -125,14 +149,22 @@
         "19",
         "26",
         "27",
-        "28"
+        "28",
+        "29",
+        "30",
+        "31",
+        "32",
+        "33",
+        "34",
+        "35",
+        "36"
       ]
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.0.0 < 7.0.0"
+      "version_requirement": ">= 4.0.0 < 8.0.0"
     }
   ],
   "tags": [


### PR DESCRIPTION
* `puppetlabs/stdlib` < `9.0.0`
* Update OS support to the latest releases where known

Closes #32
Closes #39
Closes #41
Closes #43
