### PR TITLE
os: add openeuler support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,7 +4,7 @@
 #
 class nsswitch::params {
   case $facts['operatingsystem'] {
-    /AlmaLinux|CentOS|RedHat|Rocky|Amazon|OEL|OracleLinux|Scientific|CloudLinux/: {
+    /AlmaLinux|CentOS|RedHat|Rocky|Amazon|OEL|OracleLinux|Scientific|CloudLinux|openEuler/: {
       if versioncmp($facts[operatingsystemmajrelease], '6') > 0 {
         $passwd_default     = ['files','sss']
         $shadow_default     = ['files','sss']


### PR DESCRIPTION
**Pull Request (PR) description**
Add OS support openEuler for puppet-nsswitch

**This Pull Request (PR) fixes the following issues**
This PR add [openEuler](https://www.openeuler.org/) as a supporting OS. openEuler is a community-driven Linux distro.
We've tested it in our openEuler cluster. We appreciate it if this patch can be back ported to puppet-nsswitch repository.

Thank you!